### PR TITLE
Refactor: Replaces config.js module with nconf config handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 node_modules
 
 # Config Files
-config.js
-config.example
+config.json

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Navigate to your new directory and install dependencies
     $ cd rackspace-monitoring.js
     $ npm install
 
-Copy the example config file, and replace the example credentials (username and API key) with your own. To obtain
-your API key, log into your cloud account and go to your account settings.
+Copy the example config file (config.json.example), and replace the 
+example credentials (account, username and API key) with your own. To 
+obtain your API key, log into your cloud account and go to your account 
+settings.
 
-    $ cp config.js.example config.js
-    $ vi config.js
+    $ cp config.json.example config.json
+    $ vi config.json
 
 Running Virgo.js Example
 ========================

--- a/config.js.example
+++ b/config.js.example
@@ -1,7 +1,0 @@
-var config = {};
-
-config.accountId = '1234';
-config.username = 'YOUR_USERNAME';
-config.apiKey = 'YOUR_APIKEY';
-
-module.exports = config;

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,7 @@
+{
+  "credentials": {
+    "accountId" : "1234",
+    "config.username" : "YOUR_USERNAME",
+    "config.apiKey" : "YOUR_APIKEY"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,13 +1,25 @@
 var request = require('request');
 var async = require('async');
 var virgo = require('virgo.js');
-var config = require('./config');
+var nconf = require('nconf');
 var constants = require('./constants');
 var identity = require('./lib/identity');
 
+// Account configuration
+nconf.file({file: './config.json'});
+nconf.defaults({
+  "credentials": {
+    "accountId": '1234',
+    "username": 'YOUR_USERNAME',
+    "apiKey": 'YOUR_APIKEY'
+  }
+});
 
-var identityClient = identity.createClient(config.username, config.apiKey);
-    accountId = config.accountId,
+var accountId = nconf.get('credentials:accountId'),
+    username = nconf.get('credentials:username'),
+    apiKey = nconf.get('credentials:apiKey'),
+
+    identityClient = identity.createClient(username, apiKey),
     agentServiceApiUrl = 'https://monitoring.api.rackspacecloud.com/v1.0/' + accountId + '/agent_tokens',
     agentLabel = 'virgo-js-agent';
 
@@ -17,9 +29,7 @@ function filterByVirgoAgentLabel(agentToken) {
 
 async.auto({
   getIdentityToken: function getIdentityToken(callback) {
-    identityClient.getToken(function(err, token) {
-      callback();
-    });
+    identityClient.getToken(callback);
   },
 
   deleteVirgoTokens: ['getIdentityToken', function deleteExistingVirgoTokens(callback) {
@@ -76,7 +86,7 @@ async.auto({
   }]
 }, function (err) {
   if (err) {
-    console.log(err);
+    console.log('Error: ', err);
     return;
   }
 });

--- a/lib/identity.js
+++ b/lib/identity.js
@@ -21,15 +21,17 @@ var IdentityClient = function(username, apiKey) {
 
 
 /**
- * Returns an auth token. If the cached token is expires, get a new one.
- * @param {Function} callback Expects (err, token).
+ * Returns an auth token. If the cached token is expired, get a new one.
+ * @param {Function} callback expects (err, token).
  */
 IdentityClient.prototype.getToken = function(callback) {
   if (this.token && Date.now() < this.tokenExpires) {
     callback(null, this.token);
     return;
   } else {
-    this._updateToken(callback);
+    this._updateToken(function(err, token) { 
+      callback(err, token);   
+    });
   }
 };
 
@@ -58,7 +60,7 @@ IdentityClient.prototype._updateToken = function(callback) {
     }
 
     if (!body.hasOwnProperty('access')) {
-      callback('Unexpected Behavior: ' + JSON.stringify(body));
+      callback(body);
       return;
     }    
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "async": "^0.9.0",
     "request": "^2.40.0",
-    "virgo.js": "^0.0.3"
+    "virgo.js": "~0.0.4",
+    "nconf": "~0.6.9"
   }
 }


### PR DESCRIPTION
## What

Rather than using a config.js file, this pull request uses [nconf](https://github.com/flatiron/nconf) to read a json-formatted config file. It sets default values in case the user does not add their credentials. Also adds a fix for virgo.js version in package file.
## Why

Existing index.js does not actually handle the case of a missing './config.js'. This PR does.
## How
- [x] Adds nconf to dependencies
- [x] Replaces require('./config.js') with nconf initialization
- [x] Updates readme and example configuration to reflect nconf's inputs
- [x] Changes version tracking designation for virgo.js in package.json to keep up with sweet changes upstream
